### PR TITLE
Broaden range of compatible servant versions

### DIFF
--- a/servant-elm.cabal
+++ b/servant-elm.cabal
@@ -26,8 +26,8 @@ library
                      , Servant.Elm.Generate
   build-depends:       base >= 4.7 && < 5
                      , lens
-                     , servant         == 0.5.*
-                     , servant-foreign == 0.5.*
+                     , servant         >= 0.5 && < 0.8
+                     , servant-foreign >= 0.5 && < 0.8
                      , text
                      , elm-export
   default-language:    Haskell2010


### PR DESCRIPTION
AFAICT everything should still work with Servant 0.7, the current release.