### PR TITLE
Allow to use Maps (Dicts) in record fields

### DIFF
--- a/servant-elm.cabal
+++ b/servant-elm.cabal
@@ -35,19 +35,22 @@ library
 
 test-suite servant-elm-test
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  hs-source-dirs:      test, src
   main-is:             Spec.hs
   build-depends:       aeson >= 0.9
                      , base
+                     , containers
                      , data-default
                      , directory
                      , elm-export
                      , hspec
                      , interpolate
+                     , lens
                      , mockery
                      , process
                      , servant
-                     , servant-elm
+                     , servant-foreign
+                     , text
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/Servant/Elm/Generate.hs
+++ b/src/Servant/Elm/Generate.hs
@@ -86,6 +86,7 @@ defElmImports =
     , "import Json.Decode.Extra exposing ((|:))"
     , "import Json.Encode"
     , "import Http"
+    , "import Dict exposing (Dict)"
     , "import String"
     , "import Task"
     ]


### PR DESCRIPTION
I had to add `src` to the source directories of the test-suite to be able to import `Servant.Elm.Foreign`.