### PR TITLE
Update for servant 0.8 and elm compatibility

### DIFF
--- a/examples/books/elm-package.json
+++ b/examples/books/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "circuithub/elm-json-extra": "2.2.1 <= v < 3.0.0",
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
         "evancz/elm-http": "3.0.0 <= v < 4.0.0"
     },

--- a/examples/e2e-tests/elm-package.json
+++ b/examples/e2e-tests/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
         "circuithub/elm-json-extra": "2.2.1 <= v < 3.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
         "evancz/elm-effects": "2.0.1 <= v < 3.0.0",

--- a/examples/giphy/elm-package.json
+++ b/examples/giphy/elm-package.json
@@ -8,7 +8,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "circuithub/elm-json-extra": "2.2.1 <= v < 3.0.0",
+        "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0",
         "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
         "evancz/elm-html": "4.0.2 <= v < 5.0.0",

--- a/servant-elm.cabal
+++ b/servant-elm.cabal
@@ -27,8 +27,8 @@ library
                      , Servant.Elm.Orphans
   build-depends:       base >= 4.7 && < 5
                      , lens
-                     , servant         >= 0.5
-                     , servant-foreign >= 0.5
+                     , servant         >= 0.8
+                     , servant-foreign >= 0.8
                      , text
                      , elm-export
   default-language:    Haskell2010
@@ -60,7 +60,7 @@ executable books-example
     Buildable:         False
   main-is:             generate.hs
   build-depends:       base >= 4.7 && < 5
-                     , servant >= 0.5
+                     , servant >= 0.8
                      , servant-elm
   hs-source-dirs:      examples/books
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
@@ -71,7 +71,7 @@ executable e2e-tests-example
     Buildable:         False
   main-is:             generate.hs
   build-depends:       base >= 4.7 && < 5
-                     , servant >= 0.5
+                     , servant >= 0.8
                      , servant-elm
   hs-source-dirs:      examples/e2e-tests
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
@@ -83,7 +83,7 @@ executable giphy-example
   main-is:             generate.hs
   build-depends:       base >= 4.7 && < 5
                      , elm-export >= 0.3
-                     , servant >= 0.5
+                     , servant >= 0.8
                      , servant-elm
   hs-source-dirs:      examples/giphy
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
@@ -94,7 +94,7 @@ executable readme-example
     Buildable:         False
   main-is:             generate.hs
   build-depends:       base >= 4.7 && < 5
-                     , servant >= 0.5
+                     , servant >= 0.8
                      , servant-elm
   hs-source-dirs:      examples/readme-example
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/src/Servant/Elm/Orphans.hs
+++ b/src/Servant/Elm/Orphans.hs
@@ -12,5 +12,4 @@ instance ElmType ElmTypeExpr where
   toElmType = id
 
 
-deriving instance Generic NoContent
 instance ElmType NoContent

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.10
+resolver: lts-6.17
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -13,9 +13,9 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- servant-0.7
-- servant-foreign-0.7
-- servant-server-0.7
+- servant-0.8.1
+- servant-foreign-0.8.1
+- servant-server-0.8.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/CompileSpec.hs
+++ b/test/CompileSpec.hs
@@ -60,7 +60,7 @@ createCache = do
           "exposed-modules": [],
           "dependencies": {
               "elm-lang/core": "4.0.1 <= v < 5.0.0",
-              "elm-community/elm-json-extra": "1.0.1 <= v < 2.0.0",
+              "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
               "evancz/elm-http": "3.0.1 <= v < 4.0.0"
           },
           "elm-version": "0.17.0 <= v < 0.18.0"


### PR DESCRIPTION
Heya, so I'm keen to use servant-elm with the latest servant version, and had a go at making that work. This PR contains the changes that seemed necessary and/or desirable as part of that process:

- Removal of a now-clashing orphan instance
- Bumps to lts-6.17
- Switch elm-community/elm-json-extra to elm-community/json-extra

I noticed that there's an elm-export 0.4.0.1 in Hackage, but this doesn't work with servant-elm's code as-is, and it wasn't immediately obvious to me how to update the servant-elm code accordingly. With some pointers, that might be something I could tackle.

/cc @krisajenkins