### PR TITLE
Expose all modules from library

### DIFF
--- a/servant-elm.cabal
+++ b/servant-elm.cabal
@@ -22,7 +22,7 @@ flag examples
 library
   hs-source-dirs:      src
   exposed-modules:     Servant.Elm
-  other-modules:       Servant.Elm.Foreign
+                     , Servant.Elm.Foreign
                      , Servant.Elm.Generate
                      , Servant.Elm.Orphans
   build-depends:       base >= 4.7 && < 5


### PR DESCRIPTION
This is most useful if one wants to have access to `Servant.Elm.Foreign.LangElm`.