### PR TITLE
Fix URL query identifiers

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -307,7 +307,7 @@ mkLetParams opts request =
                 "toString >> "
           in
               name <$>
-              indent 4 ("|> Maybe.map" <+> parens (toStringSrc <> "Http.encodeUri >> (++)" <+> dquotes (name <> equals)) <$>
+              indent 4 ("|> Maybe.map" <+> parens (toStringSrc <> "Http.encodeUri >> (++)" <+> dquotes (elmName <> equals)) <$>
                         "|> Maybe.withDefault" <+> dquotes empty)
 
         F.Flag ->
@@ -321,8 +321,8 @@ mkLetParams opts request =
             indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (name <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
                       "|> String.join" <+> dquotes "&")
       where
-        name =
-          elmQueryArg qarg
+        name = elmQueryArg qarg
+        elmName= qarg ^. F.queryArgName . F.argName . to (stext . F.unPathSegment)
 
 
 mkRequest :: ElmOptions -> F.Req ElmDatatype -> Doc

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -14,10 +14,10 @@ getBooks query_published query_sort query_year query_filters =
                   else
                     ""
                 , query_sort
-                    |> Maybe.map (Http.encodeUri >> (++) "query_sort=")
+                    |> Maybe.map (Http.encodeUri >> (++) "sort=")
                     |> Maybe.withDefault ""
                 , query_year
-                    |> Maybe.map (toString >> Http.encodeUri >> (++) "query_year=")
+                    |> Maybe.map (toString >> Http.encodeUri >> (++) "year=")
                     |> Maybe.withDefault ""
                 , query_filters
                     |> List.map (\val -> "query_filters[]=" ++ (val |> toString |> Http.encodeUri))


### PR DESCRIPTION
When constructing the final URL, use the original identifier.

Before:

`http://localhost:8081/api/channel/files?query_q=git`

After:

`http://localhost:8081/api/channel/files?q=git`

cc @mattjbray 