### PR TITLE
Fix elmHeaderArg

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -233,7 +233,7 @@ mkTypeSignature opts request =
 elmHeaderArg :: F.HeaderArg ElmDatatype -> Doc
 elmHeaderArg header =
   "header_" <>
-  header ^. F.headerArg . F.argName . to (stext . F.unPathSegment)
+  header ^. F.headerArg . F.argName . to (stext . T.replace "-" "_" . F.unPathSegment)
 
 
 elmCaptureArg :: F.Segment ElmDatatype -> Doc


### PR DESCRIPTION
The argument name containing a hyphen will cause a syntax error in Elm.

e.g.
```haskell
type BlahApi = "blah" :> Header "User-Agent" Text :> Get '[JSON] Blah
```

Before:
```elm
getBlah : String -> Http.Request (Blah)
getBlah header_User-Agent =
    Http.request
        { method =
            "GET"
        , headers =
            [ Http.header "User-Agent" header_User-Agent
            ]
```

After:
```elm
getBlah : String -> Http.Request (Blah)
getBlah header_User_Agent =
    Http.request
        { method =
            "GET"
        , headers =
            [ Http.header "User-Agent" header_User_Agent
            ]
```