### PR TITLE
Temporary fix for Header.

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -334,7 +334,7 @@ mkRequest opts request =
          indent i (dquotes method)
        , "headers =" <$>
          indent i
-           (elmList headers)
+           (elmListOfMaybes headers)
        , "url =" <$>
          indent i url
        , "body =" <$>
@@ -351,12 +351,12 @@ mkRequest opts request =
        request ^. F.reqMethod . to (stext . T.decodeUtf8)
 
     headers =
-        [("Http.header" <+> dquotes headerName <+>
+        [("Maybe.map (Http.header" <+> dquotes headerName <+> "<<" <+>
                  (if isElmStringType opts (header ^. F.headerArg . F.argType) then
-                     headerArgName
+                     "identity)"
                    else
-                     parens ("toString " <> headerArgName)
-                  ))
+                     "toString)"
+                  )) <+> headerArgName
         | header <- request ^. F.reqHeaders
         , headerName <- [header ^. F.headerArg . F.argName . to (stext . F.unPathSegment)]
         , headerArgName <- [elmHeaderArg header]
@@ -471,3 +471,7 @@ elmRecord = encloseSep (lbrace <> space) (line <> rbrace) (comma <> space)
 elmList :: [Doc] -> Doc
 elmList [] = lbracket <> rbracket
 elmList ds = lbracket <+> hsep (punctuate (line <> comma) ds) <$> rbracket
+
+elmListOfMaybes :: [Doc] -> Doc
+elmListOfMaybes [] = lbracket <> rbracket
+elmListOfMaybes ds = "List.filterMap identity" <+> elmList ds

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -12,7 +12,7 @@ import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import qualified Data.Text.Lazy               as L
 import qualified Data.Text.Encoding           as T
-import           Elm                          (ElmDatatype)
+import           Elm                          (ElmDatatype(..), ElmPrimitive(..))
 import qualified Elm
 import           Servant.API                  (NoContent (..))
 import           Servant.Elm.Internal.Foreign (LangElm, getEndpoints)
@@ -352,7 +352,7 @@ mkRequest opts request =
 
     headers =
         [("Maybe.map (Http.header" <+> dquotes headerName <+> "<<" <+>
-                 (if isElmStringType opts (header ^. F.headerArg . F.argType) then
+                 (if isElmMaybeStringType opts (header ^. F.headerArg . F.argType) then
                      "identity)"
                    else
                      "toString)"
@@ -453,6 +453,13 @@ this type in Elm.
 isElmStringType :: ElmOptions -> ElmDatatype -> Bool
 isElmStringType opts elmTypeExpr =
   elmTypeExpr `elem` stringElmTypes opts
+
+{- | Determines whether a type is 'Maybe String'.
+-}
+isElmMaybeStringType :: ElmOptions -> ElmDatatype -> Bool
+isElmMaybeStringType opts (ElmPrimitive (EMaybe elmTypeExpr)) = elmTypeExpr `elem` stringElmTypes opts
+isElmMaybeStringType _ _ = False
+
 
 
 -- Doc helpers

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -209,15 +209,8 @@ mkTypeSignature opts request =
 
     queryTypes :: [Doc]
     queryTypes =
-      [ arg ^. F.queryArgName . F.argType . to (elmTypeRef . wrapper)
+      [ arg ^. F.queryArgName . F.argType . to elmTypeRef
       | arg <- request ^. F.reqUrl . F.queryStr
-      , wrapper <- [
-          case arg ^. F.queryArgType of
-            F.Normal ->
-              Elm.ElmPrimitive . Elm.EMaybe
-            _ ->
-              id
-          ]
       ]
 
     bodyType :: Maybe Doc
@@ -301,7 +294,7 @@ mkLetParams opts request =
           let
             -- Don't use "toString" on Elm Strings, otherwise we get extraneous quotes.
             toStringSrc =
-              if isElmStringType opts (qarg ^. F.queryArgName . F.argType) then
+              if isElmMaybeStringType opts (qarg ^. F.queryArgName . F.argType) then
                 ""
               else
                 "toString >> "

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -454,7 +454,7 @@ isElmStringType :: ElmOptions -> ElmDatatype -> Bool
 isElmStringType opts elmTypeExpr =
   elmTypeExpr `elem` stringElmTypes opts
 
-{- | Determines whether a type is 'Maybe String'.
+{- | Determines whether a type is 'Maybe a' where 'a' is something akin to a 'String'.
 -}
 isElmMaybeStringType :: ElmOptions -> ElmDatatype -> Bool
 isElmMaybeStringType opts (ElmPrimitive (EMaybe elmTypeExpr)) = elmTypeExpr `elem` stringElmTypes opts

--- a/src/Servant/Elm/Internal/Orphans.hs
+++ b/src/Servant/Elm/Internal/Orphans.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Servant.Elm.Internal.Orphans where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,18 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.0
+resolver: lts-9.10
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
+- location:
+    git: https://github.com/phaazon/servant
+    commit: 43292f1032408b92dcab07455a440ba9b50c7aff
+  subdirs:
+    - servant
+    - servant-foreign
+  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,22 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-9.10
+resolver: lts-11.2
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-- location:
-    git: https://github.com/phaazon/servant
-    commit: 43292f1032408b92dcab07455a440ba9b50c7aff
-  subdirs:
-    - servant
-    - servant-foreign
-  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-- elm-export-0.6.0.1
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -9,8 +9,9 @@ import           Data.Text    (Text)
 import           Elm          (ElmType)
 import           GHC.Generics (Generic)
 import           Servant.API  ((:<|>), (:>), Capture, Get, GetNoContent, Header,
-                               Headers, JSON, NoContent, Post, PostNoContent,
-                               Put, QueryFlag, QueryParam, QueryParams, ReqBody)
+                               Header', Headers, JSON, NoContent, Post,
+                               PostNoContent, Put, QueryFlag, QueryParam,
+                               QueryParam', QueryParams, ReqBody, Required)
 
 data Book = Book
     { title :: String
@@ -35,6 +36,7 @@ type TestApi =
          :> QueryFlag "published"
          :> QueryParam "sort" String
          :> QueryParam "year" Int
+         :> QueryParam' '[Required] "category" String
          :> QueryParams "filters" (Maybe Bool)
          :> Get '[JSON] [Book]
   :<|> "books"
@@ -47,6 +49,8 @@ type TestApi =
   :<|> "with-a-header"
          :> Header "myStringHeader" String
          :> Header "MyIntHeader" Int
+         :> Header' '[Required] "MyRequiredStringHeader" String
+         :> Header' '[Required] "MyRequiredIntHeader" Int
          :> Get '[JSON] String
   :<|> "with-a-response-header"
          :> Get '[JSON] (Headers '[Header "myResponse" String] String)

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -4,8 +4,8 @@ import Http
 import Json.Decode exposing (..)
 
 
-getBooks : Bool -> Maybe (String) -> Maybe (Int) -> List (Maybe (Bool)) -> Http.Request (List (Book))
-getBooks query_published query_sort query_year query_filters =
+getBooks : Bool -> Maybe (String) -> Maybe (Int) -> String -> List (Maybe (Bool)) -> Http.Request (List (Book))
+getBooks query_published query_sort query_year query_category query_filters =
     let
         params =
             List.filter (not << String.isEmpty)
@@ -18,6 +18,9 @@ getBooks query_published query_sort query_year query_filters =
                     |> Maybe.withDefault ""
                 , query_year
                     |> Maybe.map (toString >> Http.encodeUri >> (++) "year=")
+                    |> Maybe.withDefault ""
+                , Just query_category
+                    |> Maybe.map (Http.encodeUri >> (++) "category=")
                     |> Maybe.withDefault ""
                 , query_filters
                     |> List.map (\val -> "query_filters[]=" ++ (val |> toString |> Http.encodeUri))

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -4,14 +4,14 @@ import Http
 import Json.Decode exposing (..)
 
 
-getWithaheader : String -> Int -> Http.Request (String)
+getWithaheader : Maybe (String) -> Maybe (Int) -> Http.Request (String)
 getWithaheader header_myStringHeader header_MyIntHeader =
     Http.request
         { method =
             "GET"
         , headers =
-            [ Http.header "myStringHeader" header_myStringHeader
-            , Http.header "MyIntHeader" (toString header_MyIntHeader)
+            List.filterMap identity [ Maybe.map (Http.header "myStringHeader" << identity) header_myStringHeader
+            , Maybe.map (Http.header "MyIntHeader" << toString) header_MyIntHeader
             ]
         , url =
             String.join "/"

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -4,15 +4,18 @@ import Http
 import Json.Decode exposing (..)
 
 
-getWithaheader : Maybe (String) -> Maybe (Int) -> Http.Request (String)
-getWithaheader header_myStringHeader header_MyIntHeader =
+getWithaheader : Maybe (String) -> Maybe (Int) -> String -> Int -> Http.Request (String)
+getWithaheader header_myStringHeader header_MyIntHeader header_MyRequiredStringHeader header_MyRequiredIntHeader =
     Http.request
         { method =
             "GET"
         , headers =
-            List.filterMap identity [ Maybe.map (Http.header "myStringHeader" << identity) header_myStringHeader
-            , Maybe.map (Http.header "MyIntHeader" << toString) header_MyIntHeader
-            ]
+            List.filterMap identity
+                [ Maybe.map (Http.header "myStringHeader") header_myStringHeader
+                , Maybe.map (Http.header "MyIntHeader" << toString) header_MyIntHeader
+                , Maybe.map (Http.header "MyRequiredStringHeader") (Just header_MyRequiredStringHeader)
+                , Maybe.map (Http.header "MyRequiredIntHeader" << toString) (Just header_MyRequiredIntHeader)
+                ]
         , url =
             String.join "/"
                 [ ""


### PR DESCRIPTION
Fix for `Header` and `Maybe` in the generated code.

See https://github.com/haskell-servant/servant/pull/843 for further details.

> The `stack.yaml` file was altered so that I can successfully have it compiled with the latest servant and servant-foreign.