### PR TITLE
Generate argument lists in the order defined by the API type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.0.2
+-------
+* Generate argument lists in the order defined by the API type. (#34)
+
 0.4.0.1
 -------
 * Remove hyphens from generated function names. (servant-foreign-0.10 no longer

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,18 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.0
+resolver: lts-9.10
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
+- location:
+    git: https://github.com/mattjbray/servant
+    commit: acc1945d60531a0e74d5f1e959c0a150e1e974bb
+  subdirs:
+    - servant
+    - servant-foreign
+  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:


### PR DESCRIPTION
Fixes #30. Depends on https://github.com/haskell-servant/servant/pull/866.