### PR TITLE
Return an `Http.Response a` for every request

### DIFF
--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -3,7 +3,7 @@ module GetBooksByIdSource exposing (..)
 import Http
 
 
-getBooksById : Int -> Http.Request (Book)
+getBooksById : Int -> Http.Request (Http.Response (Book))
 getBooksById capture_id =
     Http.request
         { method =
@@ -19,7 +19,11 @@ getBooksById capture_id =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson decodeBook
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString decodeBook response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getBooksByTitleSource.elm
+++ b/test/elm-sources/getBooksByTitleSource.elm
@@ -3,7 +3,7 @@ module GetBooksByTitleSource exposing (..)
 import Http
 
 
-getBooksByTitle : String -> Http.Request (Book)
+getBooksByTitle : String -> Http.Request (Http.Response (Book))
 getBooksByTitle capture_title =
     Http.request
         { method =
@@ -19,7 +19,11 @@ getBooksByTitle capture_title =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson decodeBook
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString decodeBook response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -4,7 +4,7 @@ import Http
 import Json.Decode exposing (..)
 
 
-getBooks : Bool -> Maybe (String) -> Maybe (Int) -> List (Maybe (Bool)) -> Http.Request (List (Book))
+getBooks : Bool -> Maybe (String) -> Maybe (Int) -> List (Maybe (Bool)) -> Http.Request (Http.Response (List (Book)))
 getBooks query_published query_sort query_year query_filters =
     let
         params =
@@ -41,7 +41,11 @@ getBooks query_published query_sort query_year query_filters =
             , body =
                 Http.emptyBody
             , expect =
-                Http.expectJson (list decodeBook)
+                Http.expectStringResponse
+                    (\response ->
+                        Result.map
+                            (\body -> { response | body = body })
+                            (decodeString (list decodeBook) response.body))
             , timeout =
                 Nothing
             , withCredentials =

--- a/test/elm-sources/getNothingSource.elm
+++ b/test/elm-sources/getNothingSource.elm
@@ -3,7 +3,7 @@ module GetNothingSource exposing (..)
 import Http
 
 
-getNothing : Http.Request (NoContent)
+getNothing : Http.Request (Http.Response (NoContent))
 getNothing =
     Http.request
         { method =
@@ -19,9 +19,9 @@ getNothing =
             Http.emptyBody
         , expect =
             Http.expectStringResponse
-                (\{ body } ->
-                    if String.isEmpty body then
-                        Ok NoContent
+                (\response ->
+                    if String.isEmpty response.body then
+                        Ok { response | body = NoContent }
                     else
                         Err "Expected the response body to be empty"
                 )

--- a/test/elm-sources/getOneSource.elm
+++ b/test/elm-sources/getOneSource.elm
@@ -4,7 +4,7 @@ import Http
 import Json.Decode exposing (..)
 
 
-getOne : Http.Request (Int)
+getOne : Http.Request (Http.Response (Int))
 getOne =
     Http.request
         { method =
@@ -19,7 +19,11 @@ getOne =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson int
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString int response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getOneWithDynamicUrlSource.elm
+++ b/test/elm-sources/getOneWithDynamicUrlSource.elm
@@ -4,7 +4,7 @@ import Http
 import Json.Decode exposing (..)
 
 
-getOne : String -> Http.Request (Int)
+getOne : String -> Http.Request (Http.Response (Int))
 getOne urlBase =
     Http.request
         { method =
@@ -19,7 +19,11 @@ getOne urlBase =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson int
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString int response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -4,7 +4,7 @@ import Http
 import Json.Decode exposing (..)
 
 
-getWithaheader : String -> Int -> Http.Request (String)
+getWithaheader : String -> Int -> Http.Request (Http.Response (String))
 getWithaheader header_myStringHeader header_MyIntHeader =
     Http.request
         { method =
@@ -21,7 +21,11 @@ getWithaheader header_myStringHeader header_MyIntHeader =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson string
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString string response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/getWitharesponseheaderSource.elm
+++ b/test/elm-sources/getWitharesponseheaderSource.elm
@@ -4,7 +4,7 @@ import Http
 import Json.Decode exposing (..)
 
 
-getWitharesponseheader : Http.Request (String)
+getWitharesponseheader : Http.Request (Http.Response (String))
 getWitharesponseheader =
     Http.request
         { method =
@@ -19,7 +19,11 @@ getWitharesponseheader =
         , body =
             Http.emptyBody
         , expect =
-            Http.expectJson string
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString string response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/postBooksSource.elm
+++ b/test/elm-sources/postBooksSource.elm
@@ -3,7 +3,7 @@ module PostBooksSource exposing (..)
 import Http
 
 
-postBooks : Book -> Http.Request (NoContent)
+postBooks : Book -> Http.Request (Http.Response (NoContent))
 postBooks body =
     Http.request
         { method =
@@ -19,9 +19,9 @@ postBooks body =
             Http.jsonBody (encodeBook body)
         , expect =
             Http.expectStringResponse
-                (\{ body } ->
-                    if String.isEmpty body then
-                        Ok NoContent
+                (\response ->
+                    if String.isEmpty response.body then
+                        Ok { response | body = NoContent }
                     else
                         Err "Expected the response body to be empty"
                 )

--- a/test/elm-sources/postTwoSource.elm
+++ b/test/elm-sources/postTwoSource.elm
@@ -5,7 +5,7 @@ import Json.Decode exposing (..)
 import Json.Encode
 
 
-postTwo : String -> Http.Request (Maybe (Int))
+postTwo : String -> Http.Request (Http.Response (Maybe (Int)))
 postTwo body =
     Http.request
         { method =
@@ -20,7 +20,11 @@ postTwo body =
         , body =
             Http.jsonBody (Json.Encode.string body)
         , expect =
-            Http.expectJson (maybe int)
+            Http.expectStringResponse
+                (\response ->
+                    Result.map
+                        (\body -> { response | body = body })
+                        (decodeString (maybe int) response.body))
         , timeout =
             Nothing
         , withCredentials =

--- a/test/elm-sources/putNothingSource.elm
+++ b/test/elm-sources/putNothingSource.elm
@@ -3,7 +3,7 @@ module PutNothingSource exposing (..)
 import Http
 
 
-putNothing : Http.Request (())
+putNothing : Http.Request (Http.Response (()))
 putNothing =
     Http.request
         { method =
@@ -19,9 +19,9 @@ putNothing =
             Http.emptyBody
         , expect =
             Http.expectStringResponse
-                (\{ body } ->
-                    if String.isEmpty body then
-                        Ok ()
+                (\response ->
+                    if String.isEmpty response.body then
+                        Ok { response | body = () }
                     else
                         Err "Expected the response body to be empty"
                 )


### PR DESCRIPTION
I could have sworn there was an issue already, but I guess not.

In any case, with the way the code is generated now, we have no way of ever getting access to the response. But sometimes the header is useful. Currently, the only time you get access to the response body is if the request failed. If we just always return `Response a`, then users of this package can decide if they care or not about the response.

This is a breaking change. If this seems like too intrusive of a move, would you accept a second function that always made a `Response a`? If not a second function, what about options?