### PR TITLE
Filter out forbidden headers

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -198,6 +198,7 @@ mkTypeSignature opts request =
     headerTypes =
       [ header ^. F.headerArg . F.argType . to elmTypeRef
       | header <- request ^. F.reqHeaders
+      , isNotCookie header
       ]
 
     urlCaptureTypes :: [Doc]
@@ -253,6 +254,14 @@ elmBodyArg =
   "body"
 
 
+isNotCookie :: F.HeaderArg f -> Bool
+isNotCookie header =
+   header
+     ^. F.headerArg
+      . F.argName
+      . to ((/= "cookie") . T.toLower . F.unPathSegment)
+
+
 mkArgs
   :: ElmOptions
   -> F.Req ElmDatatype
@@ -266,6 +275,7 @@ mkArgs opts request =
     , -- Headers
       [ elmHeaderArg header
       | header <- request ^. F.reqHeaders
+      , isNotCookie header
       ]
     , -- URL Captures
       [ elmCaptureArg segment
@@ -358,6 +368,7 @@ mkRequest opts request =
                      parens ("toString " <> headerArgName)
                   ))
         | header <- request ^. F.reqHeaders
+        , isNotCookie header 
         , headerName <- [header ^. F.headerArg . F.argName . to (stext . F.unPathSegment)]
         , headerArgName <- [elmHeaderArg header]
         ]


### PR DESCRIPTION
One of our servant API endpoints specifies the Cookie header in the request, and so servant-elm happily generates elm code to set that header. This code throws a js runtime error.

Turns out "Cookie" is one of a list of [forbidden header names](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) that can't be set programmatically. The browser sets the cookie header automatically, I'm not sure about all the others.

This patch currently just filters any headers matching "Cookie" out of the list comprehensions that generate types, header args, and Http function calls.

I'm more than happy to extend it to work with all the forbidden headers, and/or implement it in a different style if you prefer.