### PR TITLE
use the "elmName" rather than "name" for query flags and param lists

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -317,13 +317,13 @@ mkLetParams opts request =
 
         F.Flag ->
             "if" <+> name <+> "then" <$>
-            indent 4 (dquotes (name <> equals)) <$>
+            indent 4 (dquotes (elmName <> equals)) <$>
             indent 2 "else" <$>
             indent 4 (dquotes empty)
 
         F.List ->
             name <$>
-            indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (name <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
+            indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (elmName <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
                       "|> String.join" <+> dquotes "&")
       where
         name = elmQueryArg qarg

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -311,23 +311,23 @@ mkLetParams opts request =
               else
                 "toString >> "
           in
-              (if wrapped then name else "Just" <+> name) <$>
-              indent 4 ("|> Maybe.map" <+> parens (toStringSrc <> "Http.encodeUri >> (++)" <+> dquotes (elmName <> equals)) <$>
+              (if wrapped then elmName else "Just" <+> elmName) <$>
+              indent 4 ("|> Maybe.map" <+> parens (toStringSrc <> "Http.encodeUri >> (++)" <+> dquotes (name <> equals)) <$>
                         "|> Maybe.withDefault" <+> dquotes empty)
 
         F.Flag ->
-            "if" <+> name <+> "then" <$>
-            indent 4 (dquotes (elmName <> equals)) <$>
+            "if" <+> elmName <+> "then" <$>
+            indent 4 (dquotes (name <> equals)) <$>
             indent 2 "else" <$>
             indent 4 (dquotes empty)
 
         F.List ->
-            name <$>
-            indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (elmName <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
+            elmName <$>
+            indent 4 ("|> List.map" <+> parens (backslash <> "val ->" <+> dquotes (name <> "[]=") <+> "++ (val |> toString |> Http.encodeUri)") <$>
                       "|> String.join" <+> dquotes "&")
       where
-        name = elmQueryArg qarg
-        elmName= qarg ^. F.queryArgName . F.argName . to (stext . F.unPathSegment)
+        elmName = elmQueryArg qarg
+        name = qarg ^. F.queryArgName . F.argName . to (stext . F.unPathSegment)
 
 
 mkRequest :: ElmOptions -> F.Req ElmDatatype -> Doc

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -10,7 +10,7 @@ getBooks query_published query_sort query_year query_category query_filters =
         params =
             List.filter (not << String.isEmpty)
                 [ if query_published then
-                    "query_published="
+                    "published="
                   else
                     ""
                 , query_sort
@@ -23,7 +23,7 @@ getBooks query_published query_sort query_year query_category query_filters =
                     |> Maybe.map (Http.encodeUri >> (++) "category=")
                     |> Maybe.withDefault ""
                 , query_filters
-                    |> List.map (\val -> "query_filters[]=" ++ (val |> toString |> Http.encodeUri))
+                    |> List.map (\val -> "filters[]=" ++ (val |> toString |> Http.encodeUri))
                     |> String.join "&"
                 ]
     in


### PR DESCRIPTION
Looking at the [servant docs here](http://hackage.haskell.org/package/servant-0.14.1/docs/Servant-API-QueryParam.html), it looks like the query flags and query parameter lists are being generated incorrectly.  Although I did have to change the tests, so maybe this is the expected behavior and I'm missing something.

It's rendering `"query_paramName="`, which is the Elm variable name, as opposed to just `"paramName="`, which I think should be correct. Somewhat confusingly, the former is called `name` in the code while the latter is called `elmName`. Maybe that's where the mix up came from?

